### PR TITLE
Update Scan.py

### DIFF
--- a/server/Scan.py
+++ b/server/Scan.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import os, sys, subprocess, glob, argparse, time
+os.chdir(os.path.dirname(__file__))
 sys.path.insert(0, 'codeAnalysis/')
 sys.path.insert(0, 'codeAnalysis/Rules/')
 


### PR DESCRIPTION
Avoid relative path import errors when using `python3 ./server/Scan.py`